### PR TITLE
Test-KrbPasswordReset

### DIFF
--- a/Krbtgt/Krbtgt.psd1
+++ b/Krbtgt/Krbtgt.psd1
@@ -3,7 +3,7 @@
 	RootModule	      = 'Krbtgt.psm1'
 	
 	# Version number of this module.
-	ModuleVersion	  = '1.0.0'
+	ModuleVersion	  = '1.0.1'
 	
 	# ID used to uniquely identify this module
 	GUID			  = '38a69268-94ad-40ff-93df-c31ad079183a'

--- a/Krbtgt/changelog.md
+++ b/Krbtgt/changelog.md
@@ -1,3 +1,7 @@
 ﻿# Changelog
+## 1.0.1 (2019-07-15)
+ - Fix: Test-KrbPasswordReset is not automatically picking up DCs if none were specified
+ - Fix: Test-KrbPasswordReset ignores explicitly specified list of DCs
+
 ## 1.0.0 (2019-04-05)
  - New: Initial Release

--- a/Krbtgt/en-us/strings.psd1
+++ b/Krbtgt/en-us/strings.psd1
@@ -51,6 +51,7 @@
 	'Sync-KrbAccount.Connecting'				    = 'Connecting to "{0}" in order to synchronize {1}'
 	'Sync-KrbAccount.ConnectError'				    = 'Failed to connect to {0}'
 	
+	'Test-KrbPasswordReset.FailedDCResolution'	    = 'Failed to resolve domain controllers from {0} to test synchronization against. Ensure AD services are available.'
 	'Test-KrbPasswordReset.CreatingCanary'		    = 'Creating canary account to test password reset: {0}'
 	'Test-KrbPasswordReset.FailedCanaryCreation'    = 'Failed to create the canary account: {0}'
 	'Test-KrbPasswordReset.ResettingPassword'	    = 'Resetting password for account: {0}'

--- a/Krbtgt/functions/Test-KrbPasswordReset.ps1
+++ b/Krbtgt/functions/Test-KrbPasswordReset.ps1
@@ -51,6 +51,23 @@
 	
 	begin
 	{
+		#region Ensure Domain Controller parameter is filled
+		if (-not $DomainController)
+		{
+			try
+			{
+				$DomainController = (Get-ADDomainController -Server $PDCEmulator -Filter * -ErrorAction Stop).HostName | Where-Object {
+					$_ -ne $PDCEmulator
+				}
+			}
+			catch
+			{
+				Stop-PSFFunction -String 'Test-KrbPasswordReset.FailedDCResolution' -StringValues $PDCEmulator -ErrorRecord $_
+				return
+			}
+		}
+		#endregion Ensure Domain Controller parameter is filled
+		
 		#region Create a test account to test SO replication with
 		try
 		{
@@ -64,19 +81,6 @@
 			return
 		}
 		#endregion Create a test account to test SO replication with
-		
-		#region Ensure Domain Controller parameter is filled
-		if (-not $DomainController)
-		{
-			try
-			{
-				$DomainController = (Get-ADDomainController -Server $PDCEmulator -Filter * -ErrorAction Stop).HostName | Where-Object {
-					$_ -ne $PDCEmulator
-				}
-			}
-			catch { throw }
-		}
-		#endregion Ensure Domain Controller parameter is filled
 	}
 	process
 	{

--- a/Krbtgt/functions/Test-KrbPasswordReset.ps1
+++ b/Krbtgt/functions/Test-KrbPasswordReset.ps1
@@ -66,7 +66,7 @@
 		#endregion Create a test account to test SO replication with
 		
 		#region Ensure Domain Controller parameter is filled
-		if (Test-PSFParameterBinding -ParameterName 'DomainController')
+		if (-not $DomainController)
 		{
 			try
 			{

--- a/install.ps1
+++ b/install.ps1
@@ -45,7 +45,7 @@ Param (
 $ModuleName = "Krbtgt"
 
 # Base path to the github repository
-$BaseUrl = "https://github.com/<InsertUsernameHere>/Krbtgt"
+$BaseUrl = "https://github.com/PSSecTools/Krbtgt"
 
 # If the module is in a subfolder of the cloned repository, specify relative path here. Empty string to skip.
 $SubFolder = "Krbtgt"


### PR DESCRIPTION
 - Fix: Test-KrbPasswordReset is not automatically picking up DCs if none were specified
 - Fix: Test-KrbPasswordReset ignores explicitly specified list of DCs