### PR TITLE
Update Sync-LdapObjectParallel.ps1

### DIFF
--- a/Krbtgt/internal/functions/Sync-LdapObjectParallel.ps1
+++ b/Krbtgt/internal/functions/Sync-LdapObjectParallel.ps1
@@ -56,7 +56,7 @@
 		$Target,
 		
 		[int]
-		$Throttle = ($env:NUMBER_OF_PROCESSORS * 8),
+		$Throttle = ([int] $env:NUMBER_OF_PROCESSORS) * 8,
 		
 		[PSCredential]
 		$Credential,


### PR DESCRIPTION
Fixes an issue of wrong calculation for Throttle. $env:Number_of_processors is a string. 

This means on my computer doing $env:NUMBER_OF_PROCESSORS*8 gives you 1616161616161616 and this blows up. On my old processor it was 32x8 which again would blow up.

While ([int] $env:NUMBER_OF_PROCESSORS) * 8 gives you 128

This should fix https://github.com/PSSecTools/Krbtgt/issues/15