### PR TITLE
Wrong usage of repadmin /replsingleobj

### DIFF
--- a/Krbtgt/functions/Sync-KrbAccount.ps1
+++ b/Krbtgt/functions/Sync-KrbAccount.ps1
@@ -103,7 +103,7 @@
 					if ($pwdLastSetLocal -ne $PwdLastSet) { $result = $false }
 					
 					[PSCustomObject]@{
-						ComputerName = SourceDC
+						ComputerName = $SourceDC
 						Success	     = $result
 						Message	     = ($message | Where-Object { $_ })
 						ExitCode	 = $LASTEXITCODE

--- a/Krbtgt/functions/Sync-KrbAccount.ps1
+++ b/Krbtgt/functions/Sync-KrbAccount.ps1
@@ -95,15 +95,15 @@
 						$PwdLastSet
 					)
 					
-					$message = repadmin.exe /replsingleobj $env:COMPUTERNAME $TargetDC $KrbtgtDN *>&1
+					$message = repadmin.exe /replsingleobj $TargetDC $SourceDC $KrbtgtDN *>&1
 					$result = 0 -eq $LASTEXITCODE
 					
 					# Verify the password change was properly synced
-					$pwdLastSetLocal = [System.DateTime]::FromFileTimeUtc((Get-ADObject -Identity $KrbtgtDN -Server $env:COMPUTERNAME -Properties PwdLastSet).PwdLastSet)
+					$pwdLastSetLocal = [System.DateTime]::FromFileTimeUtc((Get-ADObject -Identity $KrbtgtDN -Server $SourceDC -Properties PwdLastSet).PwdLastSet)
 					if ($pwdLastSetLocal -ne $PwdLastSet) { $result = $false }
 					
 					[PSCustomObject]@{
-						ComputerName = $env:COMPUTERNAME
+						ComputerName = SourceDC
 						Success	     = $result
 						Message	     = ($message | Where-Object { $_ })
 						ExitCode	 = $LASTEXITCODE


### PR DESCRIPTION
It seems you are using $Env:ComputerName and wrong order for synchronization. Either this is by design or wrong

My mitake. You're using Invoke-PSFCommand - I didn't notice. While the order is still wrong (It's $target $source, not $Source $Target) maybe it's how it's supposed to be.